### PR TITLE
Recipes With Fewest Ingredients Endpoint

### DIFF
--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -5,7 +5,7 @@ var pry = require('pryjs');
 const fetch = require('node-fetch');
 require('dotenv').config();
 var foodArray = ["Chicken", "Beef", "Tofu", "pastas", "speghetti", "noodles"]
-
+// recipes endpoint
 router.get('/', async function(req, res) {
   const getRecipes = async () => {
     //constructing geocoding url
@@ -19,13 +19,28 @@ router.get('/', async function(req, res) {
   res.setHeader("Content-Type", "application/json");
   res.status(200).send(JSON.stringify(data));
 });
-
+// cooktime endpoint
 router.get('/cookTime', async function(req, res) {
   var food = foodArray[Math.floor(Math.random()*foodArray.length)]
 
   const getRecipes = async () => {
     //constructing geocoding url
     const edamamUrl = new URL(`https://api.edamam.com/search?q=${food}&app_id=${process.env.APP_ID}&app_key=${process.env.APP_KEY}&time=${req.query.time}`)
+    const recipesData = await mainFetch(edamamUrl);
+
+    // _forecastFormatter will format the data received fron api key according to our needs.
+    return await  _recipeFormatter(recipesData)
+  }
+  var data =  await getRecipes();
+  res.setHeader("Content-Type", "application/json");
+  res.status(200).send(JSON.stringify(data));
+});
+// ingredients endpoint
+router.get('/ingredients', async function(req, res) {
+  var food = foodArray[Math.floor(Math.random()*foodArray.length)]
+  const getRecipes = async () => {
+    //constructing geocoding url
+    const edamamUrl = new URL(`https://api.edamam.com/search?q=${food}&app_id=${process.env.APP_ID}&app_key=${process.env.APP_KEY}&ingr=${req.query.ingr}`)
     const recipesData = await mainFetch(edamamUrl);
 
     // _forecastFormatter will format the data received fron api key according to our needs.

--- a/spec/recipes.spec.js
+++ b/spec/recipes.spec.js
@@ -11,7 +11,7 @@ describe('Edamam Recipes API', () => {
     // shell.exec('npx sequelize db:seed:all')
   });
 
-
+//recipes endpoint
   describe('Test GET /api/v1/recipes', () => {
     test('should return a 200 status and all recipes within the desired search parameters', () => {
       return request(app).get('/api/v1/recipes?q=chicken').then(response => {
@@ -25,7 +25,7 @@ describe('Edamam Recipes API', () => {
       })
     })
   });
-
+//cookTime endpoint
   describe('Test GET /api/v1/recipes/cookTime', () => {
     test('should return a 200 status and all recipes within the desired search parameters', () => {
       return request(app).get('/api/v1/recipes/cookTime?time=15-30').then(response => {
@@ -38,6 +38,30 @@ describe('Edamam Recipes API', () => {
         expect(Object.keys(response.body.recipe1)).toContain('ingredients')
         expect(response.body.recipe1.cook_time).toBeGreaterThanOrEqual(15)
         expect(response.body.recipe1.cook_time).toBeLessThanOrEqual(30)
+      })
+    })
+  });
+  //fewest ingredients endpoint
+  describe('Test GET /api/v1/recipes/cookTime', () => {
+    test('should return a 200 status and all recipes within the desired search parameters', () => {
+      return request(app).get('/api/v1/recipes/ingredients?ingr=10').then(response => {
+        expect(response.status).toBe(200)
+        expect(response.body).toBeInstanceOf(Object)
+        expect(Object.keys(response.body.recipe1)).toContain('cook_time')
+        expect(Object.keys(response.body.recipe1)).toContain('calories')
+        expect(Object.keys(response.body.recipe1)).toContain('image')
+        expect(Object.keys(response.body.recipe1)).toContain('label')
+        expect(Object.keys(response.body.recipe1)).toContain('ingredients')
+        expect(response.body.recipe1.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe2.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe3.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe4.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe5.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe6.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe7.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe8.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe9.ingredients.length).toBeLessThanOrEqual(10)
+        expect(response.body.recipe10.ingredients.length).toBeLessThanOrEqual(10)
       })
     })
   });


### PR DESCRIPTION
Closes issue #6 
Add ingredients tests, and ingredients endpoint

- [x] Tested
- [x] Route is `GET /api/v1/recipes/fewestIngredients`
- [x] Request params must include `q=FOODNAME` and `ingr=NUMBER`
- [x] FOODNAME is randomly generated using a foodsArray built by us
- [x] If the request is successful, recipe objects will be returned and `status 200`. 
- [x] If the request is not successful, a `404 status code` will be returned.

Co-authored-by: Scott Thomas <31359242+smthom05@users.noreply.github.com>